### PR TITLE
Update for PureScript 0.11, rename to SqlSquared

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ node_js: stable
 install:
   - npm install -g bower
   - npm install
-  - bower install
+  - bower install --production
 script:
   - npm run -s build
+  - bower install
   - npm run -s test
 after_success:
 - >-

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "purescript-pathy": "^4.0.0",
     "purescript-profunctor": "^3.0.0",
     "purescript-profunctor-lenses": "^3.2.0",
-    "purescript-ejson": "^9.0.0"
+    "purescript-ejson": "^9.0.0",
+    "purescript-argonaut-codecs": "^3.0.1"
   },
   "devDependencies": {
     "purescript-argonaut": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -15,17 +15,17 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^2.4.0",
-    "purescript-matryoshka": "^0.2.0",
-    "purescript-pathy": "^3.0.2",
-    "purescript-profunctor": "^2.0.0",
-    "purescript-profunctor-lenses": "^2.6.0",
-    "purescript-ejson": "^8.0.0"
+    "purescript-prelude": "^3.0.0",
+    "purescript-matryoshka": "^0.3.0",
+    "purescript-pathy": "^4.0.0",
+    "purescript-profunctor": "^3.0.0",
+    "purescript-profunctor-lenses": "^3.2.0",
+    "purescript-ejson": "^9.0.0"
   },
   "devDependencies": {
-    "purescript-argonaut": "^2.0.0",
-    "purescript-search": "^2.0.0",
-    "purescript-debug": "^2.0.0",
-    "purescript-test-unit": "^10.1.0"
+    "purescript-argonaut": "^3.0.0",
+    "purescript-search": "^3.0.0",
+    "purescript-debug": "^3.0.0",
+    "purescript-test-unit": "^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-    "name": "purescript-sqlsquare",
-    "license": "Apache-2.0",
-    "scripts": {
-        "build": "pulp build -- --censor-lib --strict --stash",
-        "test": "pulp test -- --censor-lib --strict --stash"
-    },
-    "dependencies": {
-        "pulp": "^10.0.4",
-        "purescript": "^0.10.7",
-        "purescript-psa": "^0.4.0"
-    }
+  "private": true,
+  "scripts": {
+    "build": "pulp build -- --censor-lib --strict --stash",
+    "test": "pulp test"
+  },
+  "dependencies": {
+    "pulp": "^11.0.0",
+    "purescript": "^0.11.4",
+    "purescript-psa": "^0.5.1"
+  }
 }

--- a/src/SqlSquare.purs
+++ b/src/SqlSquare.purs
@@ -1,4 +1,4 @@
-module SqlSquare
+module SqlSquared
   ( Sql
   , print
   , encodeJson
@@ -19,10 +19,10 @@ import Data.Json.Extended as EJ
 
 import Matryoshka (cata, anaM)
 
-import SqlSquare.Signature as Sig
-import SqlSquare.Lenses as Lenses
-import SqlSquare.Constructors as Constructors
-import SqlSquare.Parser as Parser
+import SqlSquared.Signature as Sig
+import SqlSquared.Lenses as Lenses
+import SqlSquared.Constructors as Constructors
+import SqlSquared.Parser as Parser
 
 import Test.StrongCheck.Gen as Gen
 

--- a/src/SqlSquare/Constructors.purs
+++ b/src/SqlSquare/Constructors.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Constructors where
+module SqlSquared.Constructors where
 
 import Prelude
 
@@ -12,29 +12,29 @@ import Data.Maybe (Maybe(..))
 
 import Matryoshka (class Corecursive, embed)
 
-import SqlSquare.Signature as Sig
-import SqlSquare.Utils ((∘))
+import SqlSquared.Signature as Sig
+import SqlSquared.Utils ((∘))
 
 vari ∷ ∀ t f. Corecursive t (Sig.SqlF f) ⇒ String → t
-vari s = embed $ Sig.Vari s
+vari = embed ∘ Sig.Vari
 
 bool ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ Boolean → t
-bool b = embed $ Sig.Literal $ Boolean b
+bool = embed ∘ Sig.Literal ∘ Boolean
 
 null ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ t
 null = embed $ Sig.Literal Null
 
 int ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ Int → t
-int i = embed $ Sig.Literal $ Integer i
+int = embed ∘ Sig.Literal ∘ Integer
 
 num ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ Number → t
-num i = embed $ Sig.Literal $ Decimal $ HN.fromNumber i
+num = embed ∘ Sig.Literal ∘ Decimal ∘ HN.fromNumber
 
 hugeNum ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ HN.HugeNum → t
-hugeNum hn = embed $ Sig.Literal $ Decimal hn
+hugeNum = embed ∘ Sig.Literal ∘ Decimal
 
 string ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ String → t
-string s = embed $ Sig.Literal $ String s
+string = embed ∘ Sig.Literal ∘ String
 
 unop ∷ ∀ t f. Corecursive t (Sig.SqlF f) ⇒ Sig.UnaryOperator → t → t
 unop op expr = embed $ Sig.Unop { op, expr }
@@ -42,20 +42,20 @@ unop op expr = embed $ Sig.Unop { op, expr }
 binop ∷ ∀ t f. Corecursive t (Sig.SqlF f) ⇒ Sig.BinaryOperator → t → t → t
 binop op lhs rhs = embed $ Sig.Binop { op, lhs, rhs }
 
-set ∷ ∀ t f g. (Corecursive t (Sig.SqlF g), F.Foldable f) ⇒ f t → t
-set l = embed $ Sig.SetLiteral $ L.fromFoldable l
+set ∷ ∀ t f g. Corecursive t (Sig.SqlF g) ⇒ F.Foldable f ⇒ f t → t
+set = embed ∘ Sig.SetLiteral ∘ L.fromFoldable
 
-array ∷ ∀ t f. (Corecursive t (Sig.SqlF EJsonF), F.Foldable f) ⇒ f t → t
-array l = embed $ Sig.Literal $ Array $ Arr.fromFoldable l
+array ∷ ∀ t f. Corecursive t (Sig.SqlF EJsonF) ⇒ F.Foldable f ⇒ f t → t
+array = embed ∘ Sig.Literal ∘ Array ∘ Arr.fromFoldable
 
-map_ ∷ ∀ t. (Corecursive t (Sig.SqlF EJsonF), Ord t) ⇒ Map.Map t t → t
-map_ m = embed $ Sig.Literal $ Map ∘ EJsonMap $ Arr.fromFoldable $ Map.toList m
+map_ ∷ ∀ t. Corecursive t (Sig.SqlF EJsonF) ⇒ Ord t ⇒ Map.Map t t → t
+map_ = embed ∘ Sig.Literal ∘ Map ∘ EJsonMap ∘ Map.toUnfoldable
 
 splice ∷ ∀ t f. Corecursive t (Sig.SqlF f) ⇒ Maybe t → t
-splice m = embed $ Sig.Splice m
+splice = embed ∘ Sig.Splice
 
 ident ∷ ∀ t f. Corecursive t (Sig.SqlF f) ⇒ String → t
-ident i = embed $ Sig.Ident i
+ident = embed ∘ Sig.Ident
 
 match ∷ ∀ t f. Corecursive t (Sig.SqlF f) ⇒ t → L.List (Sig.Case t) → Maybe t → t
 match expr cases else_ = embed $ Sig.Match { expr, cases, else_ }
@@ -78,7 +78,8 @@ then_ t f = f t
 
 select
   ∷ ∀ t f
-  . (Corecursive t (Sig.SqlF EJsonF), F.Foldable f)
+  . Corecursive t (Sig.SqlF EJsonF)
+  ⇒ F.Foldable f
   ⇒ Boolean
   → f (Sig.Projection t)
   → Maybe (Sig.Relation t)

--- a/src/SqlSquare/Lenses.purs
+++ b/src/SqlSquare/Lenses.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Lenses where
+module SqlSquared.Lenses where
 
 import Prelude
 
@@ -12,8 +12,8 @@ import Data.NonEmpty as NE
 
 import Matryoshka (class Recursive, class Corecursive, embed, project)
 
-import SqlSquare.Signature as S
-import SqlSquare.Utils (type (×), (∘), (⋙))
+import SqlSquared.Signature as S
+import SqlSquared.Utils (type (×), (∘), (⋙))
 
 _GroupBy ∷ ∀ a. Iso' (S.GroupBy a) {keys ∷ L.List a, having ∷ M.Maybe a}
 _GroupBy = _Newtype
@@ -131,7 +131,8 @@ _tablePath = lens _.tablePath _{ tablePath = _ }
 
 _SetLiteral
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (L.List t)
 _SetLiteral = prism' (embed ∘ S.SetLiteral) $ project ⋙ case _ of
   S.SetLiteral lst → M.Just lst
@@ -139,7 +140,8 @@ _SetLiteral = prism' (embed ∘ S.SetLiteral) $ project ⋙ case _ of
 
 _Literal
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (f t)
 _Literal = prism' (embed ∘ S.Literal) $ project ⋙ case _ of
   S.Literal js → M.Just js
@@ -147,7 +149,8 @@ _Literal = prism' (embed ∘ S.Literal) $ project ⋙ case _ of
 
 _ArrayLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t (Array t)
 _ArrayLiteral = prism' (embed ∘ S.Literal ∘ EJ.Array) $ project ⋙ case _ of
   S.Literal (EJ.Array a) → M.Just a
@@ -155,7 +158,8 @@ _ArrayLiteral = prism' (embed ∘ S.Literal ∘ EJ.Array) $ project ⋙ case _ o
 
 _MapLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t (Array (t × t))
 _MapLiteral = prism' (embed ∘ S.Literal ∘ EJ.Map ∘ EJ.EJsonMap) $ project ⋙ case _ of
   S.Literal (EJ.Map (EJ.EJsonMap tpls)) → M.Just tpls
@@ -163,7 +167,8 @@ _MapLiteral = prism' (embed ∘ S.Literal ∘ EJ.Map ∘ EJ.EJsonMap) $ project 
 
 _Splice
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (M.Maybe t)
 _Splice = prism' (embed ∘ S.Splice) $ project ⋙ case _ of
   S.Splice m → M.Just m
@@ -171,7 +176,8 @@ _Splice = prism' (embed ∘ S.Splice) $ project ⋙ case _ of
 
 _Binop
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.BinopR t)
 _Binop = prism' (embed ∘ S.Binop) $ project ⋙ case _ of
   S.Binop b → M.Just b
@@ -179,7 +185,8 @@ _Binop = prism' (embed ∘ S.Binop) $ project ⋙ case _ of
 
 _Unop
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.UnopR t)
 _Unop = prism' (embed ∘ S.Unop) $ project ⋙ case _ of
   S.Unop r → M.Just r
@@ -187,7 +194,8 @@ _Unop = prism' (embed ∘ S.Unop) $ project ⋙ case _ of
 
 _Ident
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t String
 _Ident = prism' (embed ∘ S.Ident) $ project ⋙ case _ of
   S.Ident s → M.Just s
@@ -195,7 +203,8 @@ _Ident = prism' (embed ∘ S.Ident) $ project ⋙ case _ of
 
 _InvokeFunction
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.InvokeFunctionR t)
 _InvokeFunction = prism' (embed ∘ S.InvokeFunction) $ project ⋙ case _ of
   S.InvokeFunction r → M.Just r
@@ -203,7 +212,8 @@ _InvokeFunction = prism' (embed ∘ S.InvokeFunction) $ project ⋙ case _ of
 
 _Match
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.MatchR t)
 _Match = prism' (embed ∘ S.Match) $ project ⋙ case _ of
   S.Match r → M.Just r
@@ -211,7 +221,8 @@ _Match = prism' (embed ∘ S.Match) $ project ⋙ case _ of
 
 _Switch
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.SwitchR t)
 _Switch = prism' (embed ∘ S.Switch) $ project ⋙ case _ of
   S.Switch r → M.Just r
@@ -219,7 +230,8 @@ _Switch = prism' (embed ∘ S.Switch) $ project ⋙ case _ of
 
 _Let
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.LetR t)
 _Let = prism' (embed ∘ S.Let) $ project ⋙ case _ of
   S.Let r → M.Just r
@@ -227,7 +239,8 @@ _Let = prism' (embed ∘ S.Let) $ project ⋙ case _ of
 
 _IntLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t Int
 _IntLiteral = prism' (embed ∘ S.Literal ∘ EJ.Integer) $ project ⋙ case _ of
   S.Literal (EJ.Integer r)  → M.Just r
@@ -235,7 +248,8 @@ _IntLiteral = prism' (embed ∘ S.Literal ∘ EJ.Integer) $ project ⋙ case _ o
 
 _DecimalLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t HN.HugeNum
 _DecimalLiteral = prism' (embed ∘ S.Literal ∘ EJ.Decimal) $ project ⋙ case _ of
   S.Literal (EJ.Decimal r) → M.Just r
@@ -243,7 +257,8 @@ _DecimalLiteral = prism' (embed ∘ S.Literal ∘ EJ.Decimal) $ project ⋙ case
 
 _StringLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t String
 _StringLiteral = prism' (embed ∘ S.Literal ∘ EJ.String) $ project ⋙ case _ of
   S.Literal (EJ.String r) → M.Just r
@@ -251,7 +266,8 @@ _StringLiteral = prism' (embed ∘ S.Literal ∘ EJ.String) $ project ⋙ case _
 
 _NullLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t Unit
 _NullLiteral = prism' (const $ embed $ S.Literal EJ.Null) $ project ⋙ case _ of
   S.Literal EJ.Null → M.Just unit
@@ -259,7 +275,8 @@ _NullLiteral = prism' (const $ embed $ S.Literal EJ.Null) $ project ⋙ case _ o
 
 _BoolLiteral
   ∷ ∀ t
-  . (Recursive t (S.SqlF EJ.EJsonF), Corecursive t (S.SqlF EJ.EJsonF))
+  . Recursive t (S.SqlF EJ.EJsonF)
+  ⇒ Corecursive t (S.SqlF EJ.EJsonF)
   ⇒ Prism' t Boolean
 _BoolLiteral = prism' (embed ∘ S.Literal ∘ EJ.Boolean) $ project ⋙ case _ of
   S.Literal (EJ.Boolean b) → M.Just b
@@ -267,7 +284,8 @@ _BoolLiteral = prism' (embed ∘ S.Literal ∘ EJ.Boolean) $ project ⋙ case _ 
 
 _Vari
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t String
 _Vari = prism' (embed ∘ S.Vari) $ project ⋙ case _ of
   S.Vari r → M.Just r
@@ -275,7 +293,8 @@ _Vari = prism' (embed ∘ S.Vari) $ project ⋙ case _ of
 
 _Select
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t (S.SelectR t)
 _Select = prism' (embed ∘ S.Select) $ project ⋙ case _ of
   S.Select r → M.Just r
@@ -283,7 +302,8 @@ _Select = prism' (embed ∘ S.Select) $ project ⋙ case _ of
 
 _Parens
   ∷ ∀ t f
-  . (Recursive t (S.SqlF f), Corecursive t (S.SqlF f))
+  . Recursive t (S.SqlF f)
+  ⇒ Corecursive t (S.SqlF f)
   ⇒ Prism' t t
 _Parens = prism' (embed ∘ S.Parens) $ project ⋙ case _ of
   S.Parens t → M.Just t

--- a/src/SqlSquare/Parser/Tokenizer.purs
+++ b/src/SqlSquare/Parser/Tokenizer.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Parser.Tokenizer
+module SqlSquared.Parser.Tokenizer
   ( tokenize
   , Token(..)
   , Literal(..)
@@ -17,7 +17,7 @@ import Data.HugeNum as HN
 import Data.Char as Ch
 import Data.String as S
 
-import SqlSquare.Utils ((∘))
+import SqlSquared.Utils ((∘))
 
 import Text.Parsing.Parser as P
 import Text.Parsing.Parser.Combinators as PC
@@ -166,7 +166,7 @@ oneLineComment =
 
 multiLineComment ∷ ∀ m. Monad m ⇒ P.ParserT String m Token
 multiLineComment = do
-  PS.string "/*"
+  _ ← PS.string "/*"
   m ← collectBeforeComment ""
   pure $ Comment m
   where
@@ -264,7 +264,8 @@ parseNat =
 
 parseNegative
   ∷ ∀ m a
-  . (Monad m, Ring a)
+  . Monad m
+  ⇒ Ring a
   ⇒ P.ParserT String m a
   → P.ParserT String m a
 parseNegative p =
@@ -275,7 +276,8 @@ parseNegative p =
 
 parsePositive
   ∷ ∀ m a
-  . (Monad m, Ring a)
+  . Monad m
+  ⇒ Ring a
   ⇒ P.ParserT String m a
   → P.ParserT String m a
 parsePositive p =
@@ -283,7 +285,11 @@ parsePositive p =
     *> p
 
 parseSigned
-  ∷ ∀ m a. (Monad m, Ring a) ⇒ P.ParserT String m a → P.ParserT String m a
+  ∷ ∀ m a
+  . Monad m
+  ⇒ Ring a
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
 parseSigned p = parseNegative p  <|> parsePositive p
 
 parseExponent

--- a/src/SqlSquare/Signature.purs
+++ b/src/SqlSquare/Signature.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature
+module SqlSquared.Signature
   ( BinopR
   , UnopR
   , InvokeFunctionR
@@ -12,7 +12,7 @@ module SqlSquare.Signature
   , decodeJsonSqlF
   , arbitrarySqlF
   , genSql
-  , module SqlSquare.Utils
+  , module SqlSquared.Utils
   , module OT
   , module JT
   , module BO
@@ -45,18 +45,18 @@ import Data.Traversable as T
 
 import Matryoshka (Algebra, CoalgebraM, class Corecursive, embed)
 
-import SqlSquare.Utils (type (×), (×), (∘), (⋙))
+import SqlSquared.Utils (type (×), (×), (∘), (⋙))
 
-import SqlSquare.Signature.BinaryOperator as BO
-import SqlSquare.Signature.Case as CS
-import SqlSquare.Signature.GroupBy as GB
-import SqlSquare.Signature.JoinType as JT
-import SqlSquare.Signature.OrderBy as OB
-import SqlSquare.Signature.OrderType as OT
-import SqlSquare.Signature.Projection as PR
-import SqlSquare.Signature.Relation as RL
-import SqlSquare.Signature.UnaryOperator as UO
-import SqlSquare.Signature.Ident as ID
+import SqlSquared.Signature.BinaryOperator as BO
+import SqlSquared.Signature.Case as CS
+import SqlSquared.Signature.GroupBy as GB
+import SqlSquared.Signature.JoinType as JT
+import SqlSquared.Signature.OrderBy as OB
+import SqlSquared.Signature.OrderType as OT
+import SqlSquared.Signature.Projection as PR
+import SqlSquared.Signature.Relation as RL
+import SqlSquared.Signature.UnaryOperator as UO
+import SqlSquared.Signature.Ident as ID
 
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen

--- a/src/SqlSquare/Signature/BinaryOperator.purs
+++ b/src/SqlSquare/Signature/BinaryOperator.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.BinaryOperator where
+module SqlSquared.Signature.BinaryOperator where
 
 import Prelude
 

--- a/src/SqlSquare/Signature/Case.purs
+++ b/src/SqlSquare/Signature/Case.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.Case where
+module SqlSquared.Signature.Case where
 
 import Prelude
 

--- a/src/SqlSquare/Signature/GroupBy.purs
+++ b/src/SqlSquare/Signature/GroupBy.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.GroupBy where
+module SqlSquared.Signature.GroupBy where
 
 import Prelude
 

--- a/src/SqlSquare/Signature/Ident.purs
+++ b/src/SqlSquare/Signature/Ident.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.Ident where
+module SqlSquared.Signature.Ident where
 
 import Prelude
 

--- a/src/SqlSquare/Signature/JoinType.purs
+++ b/src/SqlSquare/Signature/JoinType.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.JoinType where
+module SqlSquared.Signature.JoinType where
 
 import Prelude
 

--- a/src/SqlSquare/Signature/OrderBy.purs
+++ b/src/SqlSquare/Signature/OrderBy.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.OrderBy where
+module SqlSquared.Signature.OrderBy where
 
 import Prelude
 
@@ -12,9 +12,9 @@ import Data.NonEmpty as NE
 
 import Matryoshka (Algebra, CoalgebraM)
 
-import SqlSquare.Signature.OrderType as OT
+import SqlSquared.Signature.OrderType as OT
 
-import SqlSquare.Utils ((×), type (×))
+import SqlSquared.Utils ((×), type (×))
 
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen

--- a/src/SqlSquare/Signature/OrderType.purs
+++ b/src/SqlSquare/Signature/OrderType.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.OrderType where
+module SqlSquared.Signature.OrderType where
 
 import Prelude
 

--- a/src/SqlSquare/Signature/Projection.purs
+++ b/src/SqlSquare/Signature/Projection.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.Projection where
+module SqlSquared.Signature.Projection where
 
 import Prelude
 
@@ -11,7 +11,7 @@ import Data.Newtype (class Newtype)
 
 import Matryoshka (Algebra, CoalgebraM)
 
-import SqlSquare.Utils ((∘))
+import SqlSquared.Utils ((∘))
 
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen

--- a/src/SqlSquare/Signature/Relation.purs
+++ b/src/SqlSquare/Signature/Relation.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.Relation where
+module SqlSquared.Signature.Relation where
 
 import Prelude
 
@@ -13,10 +13,10 @@ import Data.Path.Pathy as Pt
 
 import Matryoshka (Algebra, CoalgebraM)
 
-import SqlSquare.Signature.JoinType as JT
-import SqlSquare.Signature.Ident as ID
+import SqlSquared.Signature.JoinType as JT
+import SqlSquared.Signature.Ident as ID
 
-import SqlSquare.Utils ((∘))
+import SqlSquared.Utils ((∘))
 
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen

--- a/src/SqlSquare/Signature/UnaryOperator.purs
+++ b/src/SqlSquare/Signature/UnaryOperator.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Signature.UnaryOperator where
+module SqlSquared.Signature.UnaryOperator where
 
 import Prelude
 

--- a/src/SqlSquare/Utils.purs
+++ b/src/SqlSquare/Utils.purs
@@ -1,4 +1,4 @@
-module SqlSquare.Utils where
+module SqlSquared.Utils where
 
 import Prelude
 import Data.Tuple (Tuple(..))

--- a/test/src/Argonaut.purs
+++ b/test/src/Argonaut.purs
@@ -15,8 +15,8 @@ import Data.Set as Set
 import Data.Tuple (Tuple, fst)
 import Data.Json.Extended.Signature (EJsonF(..))
 
-import SqlSquare as S
-import SqlSquare.Utils ((×), (∘), (⋙))
+import SqlSquared as S
+import SqlSquared.Utils ((×), (∘), (⋙))
 
 import Matryoshka (ana, elgotPara, Coalgebra, ElgotAlgebra)
 

--- a/test/src/Constructors.purs
+++ b/test/src/Constructors.purs
@@ -9,8 +9,8 @@ import Data.NonEmpty as NE
 import Data.Either as E
 import Data.Path.Pathy as Pt
 
-import SqlSquare as S
-import SqlSquare.Utils ((×), (∘))
+import SqlSquared as S
+import SqlSquared.Utils ((×), (∘))
 
 import Test.Unit (suite, test, TestSuite)
 import Test.Unit.Assert as Assert

--- a/test/src/Gen.purs
+++ b/test/src/Gen.purs
@@ -15,7 +15,7 @@ import Test.StrongCheck as SC
 import Test.StrongCheck.Arbitrary as A
 import Test.Unit.Console as Console
 
-import SqlSquare (Sql, arbitrarySqlOfSize, decodeJson, encodeJson, print, tokenize)
+import SqlSquared (Sql, arbitrarySqlOfSize, decodeJson, encodeJson, print, tokenize)
 
 newtype ArbSql = ArbSql Sql
 
@@ -41,7 +41,7 @@ testTokenizer =
       SC.Success
 
 type TestEffects r =
-  ( err ∷ EXCEPTION
+  ( exception ∷ EXCEPTION
   , random ∷ RANDOM
   , console ∷ CONSOLE
   , testOutput ∷ Console.TESTOUTPUT

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -20,7 +20,7 @@ type Effects =
   ( testOutput ∷ TESTOUTPUT
   , avar ∷ AVAR
   , console ∷ CONSOLE
-  , err ∷ EXCEPTION
+  , exception ∷ EXCEPTION
   , random ∷ RANDOM
   )
 

--- a/test/src/Parse.purs
+++ b/test/src/Parse.purs
@@ -6,7 +6,7 @@ import Control.Monad.Eff (Eff)
 
 import Data.Either as E
 import Data.Foldable as F
-import SqlSquare (Sql, print, parse)
+import SqlSquared (Sql, print, parse)
 
 import Test.Unit.Console as Console
 


### PR DESCRIPTION
We didn't catch this in the original reviews, but it should have been "SqlSquared" :smile:

Also renamed this repo to match - we already had `purescript-sql-squared` lying around, but it was empty.