### PR TITLE
[qz-3635] Correct precedence when parsing join conditions

### DIFF
--- a/src/SqlSquared/Parser.purs
+++ b/src/SqlSquared/Parser.purs
@@ -601,7 +601,7 @@ stdJoinRelation = do
   _ ← keyword "join"
   right ← simpleRelation
   _ ← keyword "on"
-  clause ← expr
+  clause ← definedExpr
   pure \left →
     Sig.JoinRelation
       { left

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -15,6 +15,7 @@ import Test.Constructors as Constructors
 import Test.Argonaut as Argonaut
 import Test.Gen as Gen
 import Test.Parse as Parse
+import Test.Precedence as Precedence
 
 type Effects =
   ( testOutput ∷ TESTOUTPUT
@@ -30,5 +31,6 @@ main = do
     Constructors.testSuite
     Argonaut.testSuite
     Parse.testSuite
+    Precedence.testSuite
 
   Gen.test

--- a/test/src/Precedence.purs
+++ b/test/src/Precedence.purs
@@ -1,0 +1,32 @@
+module Test.Precedence where
+
+import Prelude
+
+import Data.Either as E
+import Matryoshka (project)
+
+import SqlSquared as S
+
+import Test.Unit (suite, test, Test, TestSuite)
+import Test.Unit.Assert as Assert
+
+testParsedSql ∷ ∀ e. (S.Sql → Test e) → String → Test e
+testParsedSql f s =
+  case S.prettyParse S.parse s of
+    E.Left err → Assert.assert ("\n" <> err) false
+    E.Right sql → f sql
+
+limitedJoinQuery ∷ String
+limitedJoinQuery = "select * from a inner join b on a.id = b.id limit 10"
+
+expectLimit ∷ S.Sql → Boolean
+expectLimit sql =
+  case project sql of
+    (S.Binop { lhs: _, rhs: _, op: S.Limit }) → true
+    _ → false
+
+testSuite ∷ ∀ e. TestSuite e
+testSuite = do
+  suite "tests for parser precedence" do
+    test "limit should have higher precedence than join condition"
+      $ testParsedSql (Assert.assert "limit parsed incorrectly" <<< expectLimit) limitedJoinQuery


### PR DESCRIPTION
Corrects the parsing of join conditions so that queries like
```
select * from a inner join b on a.id = b.id limit 10
```
parse correctly. Prior to this fix the `limit` would be considered part of the join condition and not the outer query.