### PR TITLE
Add functions for slightly prettier (indented) formatting

### DIFF
--- a/src/SqlSquared.purs
+++ b/src/SqlSquared.purs
@@ -3,8 +3,11 @@ module SqlSquared
   , SqlQuery
   , SqlModule
   , print
+  , printPretty
   , printQuery
+  , printQueryPretty
   , printModule
+  , printModulePretty
   , genSql
   , genSqlQuery
   , genSqlModule
@@ -25,7 +28,7 @@ import Matryoshka (cata, anaM)
 import SqlSquared.Constructors (array, as, as', binop, bool, buildSelect, groupBy, having, hugeNum, ident, ident', int, invokeFunction, invokeFunction', let', let_, map_, match, match', null, num, parens, projection, select, select', set, splice, string, switch, switch', then_, unop, var, when) as Constructors
 import SqlSquared.Lenses (_ArrayLiteral, _Binop, _BoolLiteral, _Case, _DecimalLiteral, _ExprRelation, _GroupBy, _Identifier, _IntLiteral, _InvokeFunction, _JoinRelation, _Let, _Literal, _MapLiteral, _Match, _NullLiteral, _OrderBy, _Parens, _Projection, _Select, _SetLiteral, _Splice, _StringLiteral, _Switch, _TableRelation, _Unop, _Var, _VarRelation, _alias, _aliasName, _args, _bindTo, _cases, _clause, _cond, _else, _expr, _filter, _groupBy, _having, _ident, _in, _isDistinct, _joinType, _keys, _left, _lhs, _name, _op, _orderBy, _projections, _relations, _rhs, _right, _tablePath) as Lenses
 import SqlSquared.Parser (Literal(..), PositionedToken, parse, parseModule, parseQuery, prettyParse) as Parser
-import SqlSquared.Signature (type (×), BinaryOperator(..), BinopR, Case(..), ExprRelR, FunctionDeclR, GroupBy(..), Ident(..), InvokeFunctionR, JoinRelR, JoinType(..), LetR, MatchR, OrderBy(..), OrderType(..), Projection(..), Relation(..), SelectR, SqlDeclF(..), SqlF(..), SqlModuleF(..), SqlQueryF(..), SwitchR, TableRelR, UnaryOperator(..), UnopR, VarRelR, binopFromString, binopToString, genBinaryOperator, genCase, genGroupBy, genJoinType, genOrderBy, genOrderType, genProjection, genRelation, genSqlDeclF, genSqlF, genSqlModuleF, genSqlQueryF, genUnaryOperator, joinTypeFromString, orderTypeFromString, printBinaryOperator, printCase, printGroupBy, printIdent, printJoinType, printOrderBy, printOrderType, printProjection, printRelation, printSqlDeclF, printSqlF, printSqlModuleF, printSqlQueryF, printUnaryOperator, unopFromString, unopToString, (×), (∘), (⋙)) as Sig
+import SqlSquared.Signature (type (×), BinaryOperator(..), BinopR, Case(..), ExprRelR, FunctionDeclR, GroupBy(..), Ident(..), InvokeFunctionR, JoinRelR, JoinType(..), LetR, MatchR, OrderBy(..), OrderType(..), Projection(..), Relation(..), SelectR, SqlDeclF(..), SqlF(..), SqlModuleF(..), SqlQueryF(..), SwitchR, TableRelR, UnaryOperator(..), UnopR, VarRelR, binopFromString, binopToString, genBinaryOperator, genCase, genGroupBy, genJoinType, genOrderBy, genOrderType, genProjection, genRelation, genSqlDeclF, genSqlF, genSqlModuleF, genSqlQueryF, genUnaryOperator, joinTypeFromString, orderTypeFromString, printBinaryOperator, printCase, printGroupBy, printIdent, printJoinType, printOrderBy, printOrderType, printProjection, printRelation, printSqlDeclF, printSqlF, printSqlFPretty, printSqlModuleF, printSqlQueryF, printUnaryOperator, unopFromString, unopToString, (×), (∘), (⋙)) as Sig
 
 type Sql = Mu (Sig.SqlF EJ.EJsonF)
 
@@ -41,6 +44,15 @@ printQuery = Sig.printSqlQueryF <<< map print
 
 printModule ∷ SqlModule → String
 printModule = Sig.printSqlModuleF <<< map print
+
+printPretty ∷ Sql → String
+printPretty = cata $ Sig.printSqlFPretty EJ.renderEJsonF
+
+printQueryPretty ∷ SqlQuery → String
+printQueryPretty = Sig.printSqlQueryF <<< map printPretty
+
+printModulePretty ∷ SqlModule → String
+printModulePretty = Sig.printSqlModuleF <<< map printPretty
 
 genSql ∷ ∀ m. Gen.MonadGen m ⇒ MonadRec m ⇒ m Sql
 genSql = Gen.sized $ anaM (Sig.genSqlF EJ.arbitraryEJsonF)

--- a/src/SqlSquared/Signature/BinaryOperator.purs
+++ b/src/SqlSquared/Signature/BinaryOperator.purs
@@ -147,3 +147,8 @@ printBinaryOperator lhs rhs = case _ of
   IntersectAll → lhs <> " INTERSECT ALL " <> rhs
   Except → lhs <> " EXCEPT " <> rhs
   UnshiftMap → "{" <> lhs <> ": " <> rhs <> "...}"
+
+printBinaryOperatorPretty ∷ String → String → BinaryOperator → String
+printBinaryOperatorPretty lhs rhs = case _ of
+  UnionAll → lhs <> "\nUNION ALL\n" <> rhs
+  other → printBinaryOperator lhs rhs other

--- a/src/SqlSquared/Signature/Relation.purs
+++ b/src/SqlSquared/Signature/Relation.purs
@@ -9,6 +9,7 @@ import Data.Either (Either(..), either)
 import Data.Foldable as F
 import Data.Maybe (Maybe)
 import Data.NonEmpty ((:|))
+import Data.String as String
 import Data.String.Gen as GenS
 import Data.Traversable as T
 import Matryoshka (Algebra, CoalgebraM)
@@ -83,7 +84,10 @@ instance traversableRelation ∷ T.Traversable Relation where
 printRelation ∷ Algebra Relation String
 printRelation = case _ of
   ExprRelation { expr, alias } →
-    "(" <> expr <> ") AS " <> ID.printIdent alias
+    let
+      indented = String.contains (String.Pattern "\n") expr
+    in
+      "(" <> expr <> (if indented then "\n" else "") <> ") AS " <> ID.printIdent alias
   VarRelation { var, alias } →
     ":" <> ID.printIdent var <> F.foldMap (\a → " AS " <> ID.printIdent a) alias
   TableRelation { path, alias } →


### PR DESCRIPTION
@rintcius hacking this in should help with the codegen test stuff you're working on. With just these handful of changes our generated queries already look pretty close to that formatting we were applying by hand:

``` sql
SELECT 
  c.c1 AS `Values of key a`, 
  c.c2 AS `Values of key id`, 
  c.c4 AS `Values of key id 2`, 
  c.c3 AS `Values of key value`
FROM
  ((SELECT 
    p5.g7 AS c1
  FROM
    (SELECT 
      `_sd_ensure_number`(r6.a) AS g7
    FROM
      `/datasource/dba83c92-955d-4bbd-8caa-0087c2e84413/ssssimple.ldjson` AS r6
    ) AS p5)
  UNION ALL
  (SELECT 
    p8.g10 AS c2, 
    p8.g12 AS c3, 
    p8.g11 AS c4
  FROM
    (SELECT 
      `_sd_ensure_number`(r9.entry.id) AS g10, 
      to_string(`_sd_ensure_number`(r9.entry.id)) AS g11, 
      `_sd_ensure_boolean`(r9.entry.value) AS g12
    FROM
      `/datasource/dba83c92-955d-4bbd-8caa-0087c2e84413/ssssst.ldjson` AS r9
    ) AS p8)
  ) AS c
```